### PR TITLE
[Editor] Add load from JSON button for LlamaOptions

### DIFF
--- a/Source/Atum/Private/Models/Llama/LlamaUnreal.cpp
+++ b/Source/Atum/Private/Models/Llama/LlamaUnreal.cpp
@@ -72,6 +72,11 @@ bool ULlamaUnreal::OnForward_Implementation(
 	return true;
 }
 
+void ULlamaUnreal::SetOptions(const FAtumLlamaOptions& NewOptions)
+{
+	Options = NewOptions;
+}
+
 bool ULlamaUnreal::Generate_Implementation(const TScriptInterface<IAtumTensor>& Input, TScriptInterface<IAtumTensor>& Output, const int32& NumNewTokens  = 10)
 {
 
@@ -105,8 +110,6 @@ bool ULlamaUnreal::Generate_Implementation(const TScriptInterface<IAtumTensor>& 
 
 bool ULlamaUnreal::LoadParams_Implementation(const FString& Path)
 {
-
-	
 
 	FString const FilePath = IAtumModule::GetContentDirectory(Path);
 	if (!FPaths::FileExists(FilePath))

--- a/Source/Atum/Public/Layers/Network/AtumNeuralNetworkLayers.h
+++ b/Source/Atum/Public/Layers/Network/AtumNeuralNetworkLayers.h
@@ -18,6 +18,8 @@ UCLASS(BlueprintType, EditInlineNew, DisplayName = "ATUM Neural Network Layers D
 class ATUM_API UAtumNeuralNetworkLayers : public UDataAsset
 {
 	GENERATED_BODY()
+
+	friend class FAtumNeuralNetworkLayersCustomization;
 	
 #if WITH_EDITORONLY_DATA
 	/**

--- a/Source/Atum/Public/Models/Llama/LlamaUnreal.h
+++ b/Source/Atum/Public/Models/Llama/LlamaUnreal.h
@@ -36,16 +36,16 @@ public:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "ATUM|Layer")
 	bool LoadParams(const FString& Path);
 
-
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "ATUM|Layer")
 	bool ToArchive(const FString& InPath, const FString& OutPath);
+
+	UFUNCTION(BlueprintCallable, Category = "ATUM|Layer")
+	void SetOptions(const FAtumLlamaOptions& NewOptions);
 
 protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (AllowPrivateAccess, ShowOnlyInnerProperties, ExposeOnSpawn))
 	FAtumLlamaOptions Options;
 
-	
-	
 };
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/AtumEditor/AtumEditor.Build.cs
+++ b/Source/AtumEditor/AtumEditor.Build.cs
@@ -28,7 +28,9 @@ public class AtumEditor : ModuleRules
 		{
 			"Atum",
 			"Core",
-			"CoreUObject"
+			"CoreUObject",
+			"Json",
+			"JsonUtilities" 
 		});
 		
 		PrivateDependencyModuleNames.AddRange(new[]
@@ -37,7 +39,8 @@ public class AtumEditor : ModuleRules
 			"GraphEditor",
 			"Slate",
 			"SlateCore",
-			"UnrealEd"
+			"UnrealEd", 
+			"DesktopWidgets"
 		});
 	}
 }

--- a/Source/AtumEditor/Private/Assets/Network/AtumNeuralNetworkLayersCustomization.cpp
+++ b/Source/AtumEditor/Private/Assets/Network/AtumNeuralNetworkLayersCustomization.cpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "Assets/Network/AtumNeuralNetworkLayersCustomization.h"
+
+#include "DesktopPlatformModule.h"
+#include "DetailLayoutBuilder.h"
+#include "Models/Llama/LlamaUnreal.h"
+#include "Models/Llama/llama_config.h"
+#include "DetailWidgetRow.h"
+#include "IDesktopPlatform.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Layers/Network/AtumNeuralNetworkLayers.h"
+#include "Misc/FileHelper.h"
+#include "Json.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SFilePathPicker.h"
+
+
+TSharedRef<IDetailCustomization> FAtumNeuralNetworkLayersCustomization::MakeInstance()
+{
+    return MakeShareable(new FAtumNeuralNetworkLayersCustomization());
+}
+
+void FAtumNeuralNetworkLayersCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+   TArray<TWeakObjectPtr<UObject>> Objects;
+    DetailBuilder.GetObjectsBeingCustomized(Objects);
+
+    // Loop over each object being customized
+    for (const TWeakObjectPtr<UObject>& Object : Objects)
+    {
+        if (UAtumNeuralNetworkLayers* Layers = Cast<UAtumNeuralNetworkLayers>(Object.Get()))
+        {
+            // Get the property handles for LayerTypes and LayerObjects
+            TSharedPtr<IPropertyHandle> LayerTypesPropertyHandle = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UAtumNeuralNetworkLayers, LayerTypes), UAtumNeuralNetworkLayers::StaticClass());
+            TSharedPtr<IPropertyHandle> LayerObjectsPropertyHandle = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UAtumNeuralNetworkLayers, LayerObjects), UAtumNeuralNetworkLayers::StaticClass());
+
+            // Create a category for LayerTypes and display its default property widget
+            IDetailCategoryBuilder& LayerTypesCategory = DetailBuilder.EditCategory("Layer Types", FText::GetEmpty(), ECategoryPriority::Important);
+            LayerTypesCategory.AddProperty(LayerTypesPropertyHandle);
+
+            if (LayerObjectsPropertyHandle.IsValid())
+            {
+                uint32 NumChildren;
+                LayerObjectsPropertyHandle->GetNumChildren(NumChildren);
+
+                for (uint32 i = 0; i < NumChildren; i++)
+                {
+                    TSharedPtr<IPropertyHandle> ChildHandle = LayerObjectsPropertyHandle->GetChildHandle(i);
+                    if (ChildHandle.IsValid())
+                    {
+                        UObject* LayerObject = nullptr;
+                        ChildHandle->GetValue(LayerObject);
+
+                        if (ULlamaUnreal* LlamaUnreal = Cast<ULlamaUnreal>(LayerObject))
+                        {
+                            // Create a new category for each LlamaUnreal object
+                            FString CategoryName = FString::Printf(TEXT("Layer Object %d"), i);
+                            IDetailCategoryBuilder& LayerObjectCategory = DetailBuilder.EditCategory(*CategoryName, FText::GetEmpty(), ECategoryPriority::Important);
+
+                            // Add a custom row for the 'Load JSON' button at the top of the category
+                            LayerObjectCategory.AddCustomRow(FText::FromString("Llama Configuration"))
+                                .WholeRowContent()
+                                [
+                                    SNew(SHorizontalBox)
+                                    + SHorizontalBox::Slot()
+                                    .AutoWidth()
+                                    [
+                                        SNew(SButton)
+                                        .Text(FText::FromString("Load options from JSON"))
+                                        .OnClicked(FOnClicked::CreateLambda([this, LlamaUnreal]() -> FReply {
+                                            // Implement the logic to load the JSON file and set the values in the LlamaUnreal object
+                                            // You can use the existing SetFromFile function or create a new one specifically for this purpose
+                                            // LlamaUnreal->SetFromFile(FilePath);
+                                            if (LlamaUnreal)
+                                            {
+                                                LoadConfigurationFromFile(LlamaUnreal);
+                                            }
+                                            return FReply::Handled();
+                                        }))
+                                    ]
+                                ];
+
+                            // Add the default property widget for this LlamaUnreal object
+                            LayerObjectCategory.AddProperty(ChildHandle);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void FAtumNeuralNetworkLayersCustomization::OnJsonFilePathPicked(const FString& FilePath, ULlamaUnreal* LlamaUnreal)
+{
+    // Implement the logic to load the JSON file and set the values in the LlamaUnreal object
+    // You can use the existing SetFromFile function or create a new one specifically for this purpose
+    // LlamaUnreal->SetFromFile(FilePath);
+}
+
+void FAtumNeuralNetworkLayersCustomization::LoadConfigurationFromFile(ULlamaUnreal* LlamaUnreal)
+{
+    IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+    if (DesktopPlatform)
+    {
+        TArray<FString> OpenFilenames;
+        DesktopPlatform->OpenFileDialog(
+            nullptr, // Parent window handle
+            TEXT("Load JSON"), // Dialog title
+            TEXT(""), // Default path
+            TEXT(""), // Default file name
+            TEXT("JSON files (*.json)|*.json"), // File types
+            EFileDialogFlags::None,
+            OpenFilenames
+        );
+
+        if (OpenFilenames.Num() > 0)
+        {
+            const FString& FilePath = OpenFilenames[0];
+            FString JsonRaw;
+            if (FFileHelper::LoadFileToString(JsonRaw, *FilePath))
+            {
+                TSharedPtr<FJsonObject> JsonObject;
+                TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonRaw);
+
+                if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
+                {
+                    // Parse the JSON and apply settings to create a new FLlamaConfig instance
+                    LlamaConfig Config;
+
+                    // Set Config fields from JsonObject
+                    Config.vocab_size = JsonObject->GetIntegerField(TEXT("vocab_size"));
+                    Config.hidden_size = JsonObject->GetIntegerField(TEXT("hidden_size"));
+                    Config.intermediate_size = JsonObject->GetIntegerField(TEXT("intermediate_size"));
+                    Config.num_hidden_layers = JsonObject->GetIntegerField(TEXT("num_hidden_layers"));
+                    Config.num_attention_heads = JsonObject->GetIntegerField(TEXT("num_attention_heads"));
+                    Config.hidden_act = std::string(TCHAR_TO_UTF8(*JsonObject->GetStringField(TEXT("hidden_act"))));
+                    Config.max_position_embeddings = JsonObject->GetIntegerField(TEXT("max_position_embeddings"));
+                    Config.initializer_range = JsonObject->GetNumberField(TEXT("initializer_range"));
+                    Config.rms_norm_eps = JsonObject->GetNumberField(TEXT("rms_norm_eps"));
+                    Config.use_cache = JsonObject->GetBoolField(TEXT("use_cache"));
+                    Config.pad_token_id = JsonObject->GetIntegerField(TEXT("pad_token_id"));
+                    Config.bos_token_id = JsonObject->GetIntegerField(TEXT("bos_token_id"));
+                    Config.eos_token_id = JsonObject->GetIntegerField(TEXT("eos_token_id"));
+                    Config.tie_word_embeddings = JsonObject->GetBoolField(TEXT("tie_word_embeddings"));
+                    Config.output_hidden_states = JsonObject->GetBoolField(TEXT("output_hidden_states"));
+                    Config.output_attentions = JsonObject->GetBoolField(TEXT("output_attentions"));
+
+                    // Apply the new Config to the LlamaUnreal instance
+                    FAtumLlamaOptions NewOptions;
+                    NewOptions.SetFrom(Config);
+                    LlamaUnreal->SetOptions(NewOptions);
+
+                    // Refresh the UI to reflect the loaded values
+                    FPropertyEditorModule& PropertyEditorModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
+                    TSharedPtr<IDetailsView> DetailsView = PropertyEditorModule.FindDetailView(TEXT("AtumNeuralNetworkEditorDetailsTab"));
+                    if (DetailsView.IsValid())
+                    {
+                        DetailsView->SetObject(LlamaUnreal, true);
+                    }   
+                }
+            }
+        }
+    }
+}

--- a/Source/AtumEditor/Private/AtumEditorModule.cpp
+++ b/Source/AtumEditor/Private/AtumEditorModule.cpp
@@ -2,7 +2,9 @@
 
 #include "AtumEditorModule.h"
 
+#include "PropertyEditorModule.h"
 #include "Assets/Network/AssetTypeActions_AtumNeuralNetwork.h"
+#include "Assets/Network/AtumNeuralNetworkLayersCustomization.h"
 
 
 #define LOCTEXT_NAMESPACE "AtumEditorModule"
@@ -15,6 +17,9 @@ void FAtumEditorModule::StartupModule()
 		LOCTEXT("AtumAssetCategory", "Machine Learning")
 	);
 	AssetTools.RegisterAssetTypeActions(AtumNeuralNetworkAssetTypeActions);
+
+	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+	PropertyModule.RegisterCustomClassLayout("AtumNeuralNetworkLayers", FOnGetDetailCustomizationInstance::CreateStatic(&FAtumNeuralNetworkLayersCustomization::MakeInstance));
 }
 
 void FAtumEditorModule::ShutdownModule()
@@ -22,6 +27,12 @@ void FAtumEditorModule::ShutdownModule()
 	if (FAssetToolsModule::IsModuleLoaded())
 	{
 		FAssetToolsModule::GetModule().Get().UnregisterAssetTypeActions(AtumNeuralNetworkAssetTypeActions);
+	}
+
+	if (FModuleManager::Get().IsModuleLoaded("PropertyEditor"))
+	{
+		FPropertyEditorModule& PropertyModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
+		PropertyModule.UnregisterCustomClassLayout("AtumNeuralNetworkLayers");
 	}
 }
 	

--- a/Source/AtumEditor/Public/Assets/Network/AtumNeuralNetworkLayersCustomization.h
+++ b/Source/AtumEditor/Public/Assets/Network/AtumNeuralNetworkLayersCustomization.h
@@ -1,0 +1,24 @@
+// © 2024 Chong-U Lim
+#pragma once
+
+#include "IDetailCustomization.h"
+#include "Input/Reply.h"
+
+class UAtumNeuralNetworkLayers;
+class ULlamaUnreal;
+
+#define LOCTEXT_NAMESPACE "LlamaUnrealCustomization"
+
+class FAtumNeuralNetworkLayersCustomization : public IDetailCustomization
+{
+public:
+	static TSharedRef<IDetailCustomization> MakeInstance();
+
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
+private:
+	void OnJsonFilePathPicked(const FString& FilePath, ULlamaUnreal* LlamaUnreal);
+	void LoadConfigurationFromFile(ULlamaUnreal* LlamaUnreal);
+};
+
+#undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
This PR adds the ability to load configuration options for a Llama model's layers from a JSON file within the Editor.
![image](https://github.com/P1ayer-1/Libtorch-UE5/assets/1178121/93b1fcf2-dd06-49c1-bbf8-0d8a4ca10739)
