### PR TITLE
[Editor] Extend JSON Loading for LlamaOptions with Default Handling

### DIFF
--- a/Source/Atum/Private/Models/Llama/LlamaUnreal.cpp
+++ b/Source/Atum/Private/Models/Llama/LlamaUnreal.cpp
@@ -72,6 +72,11 @@ bool ULlamaUnreal::OnForward_Implementation(
 	return true;
 }
 
+void ULlamaUnreal::SetOptions(const FAtumLlamaOptions& NewOptions)
+{
+	Options = NewOptions;
+}
+
 bool ULlamaUnreal::Generate_Implementation(const TScriptInterface<IAtumTensor>& Input, TScriptInterface<IAtumTensor>& Output, const int32& NumNewTokens  = 10)
 {
 
@@ -105,8 +110,6 @@ bool ULlamaUnreal::Generate_Implementation(const TScriptInterface<IAtumTensor>& 
 
 bool ULlamaUnreal::LoadParams_Implementation(const FString& Path)
 {
-
-	
 
 	FString const FilePath = IAtumModule::GetContentDirectory(Path);
 	if (!FPaths::FileExists(FilePath))

--- a/Source/Atum/Public/Layers/Network/AtumNeuralNetworkLayers.h
+++ b/Source/Atum/Public/Layers/Network/AtumNeuralNetworkLayers.h
@@ -18,6 +18,8 @@ UCLASS(BlueprintType, EditInlineNew, DisplayName = "ATUM Neural Network Layers D
 class ATUM_API UAtumNeuralNetworkLayers : public UDataAsset
 {
 	GENERATED_BODY()
+
+	friend class FAtumNeuralNetworkLayersCustomization;
 	
 #if WITH_EDITORONLY_DATA
 	/**

--- a/Source/Atum/Public/Models/Llama/LlamaUnreal.h
+++ b/Source/Atum/Public/Models/Llama/LlamaUnreal.h
@@ -36,16 +36,16 @@ public:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "ATUM|Layer")
 	bool LoadParams(const FString& Path);
 
-
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "ATUM|Layer")
 	bool ToArchive(const FString& InPath, const FString& OutPath);
+
+	UFUNCTION(BlueprintCallable, Category = "ATUM|Layer")
+	void SetOptions(const FAtumLlamaOptions& NewOptions);
 
 protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (AllowPrivateAccess, ShowOnlyInnerProperties, ExposeOnSpawn))
 	FAtumLlamaOptions Options;
 
-	
-	
 };
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/AtumEditor/AtumEditor.Build.cs
+++ b/Source/AtumEditor/AtumEditor.Build.cs
@@ -28,7 +28,9 @@ public class AtumEditor : ModuleRules
 		{
 			"Atum",
 			"Core",
-			"CoreUObject"
+			"CoreUObject",
+			"Json",
+			"JsonUtilities" 
 		});
 		
 		PrivateDependencyModuleNames.AddRange(new[]
@@ -37,7 +39,8 @@ public class AtumEditor : ModuleRules
 			"GraphEditor",
 			"Slate",
 			"SlateCore",
-			"UnrealEd"
+			"UnrealEd", 
+			"DesktopWidgets"
 		});
 	}
 }

--- a/Source/AtumEditor/Private/Assets/Network/AtumNeuralNetworkLayersCustomization.cpp
+++ b/Source/AtumEditor/Private/Assets/Network/AtumNeuralNetworkLayersCustomization.cpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "Assets/Network/AtumNeuralNetworkLayersCustomization.h"
+
+#include "DesktopPlatformModule.h"
+#include "DetailLayoutBuilder.h"
+#include "Models/Llama/LlamaUnreal.h"
+#include "Models/Llama/llama_config.h"
+#include "DetailWidgetRow.h"
+#include "IDesktopPlatform.h"
+#include "Dom/JsonObject.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonSerializer.h"
+#include "Layers/Network/AtumNeuralNetworkLayers.h"
+#include "Misc/FileHelper.h"
+#include "Json.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SFilePathPicker.h"
+
+
+TSharedRef<IDetailCustomization> FAtumNeuralNetworkLayersCustomization::MakeInstance()
+{
+    return MakeShareable(new FAtumNeuralNetworkLayersCustomization());
+}
+
+void FAtumNeuralNetworkLayersCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+   TArray<TWeakObjectPtr<UObject>> Objects;
+    DetailBuilder.GetObjectsBeingCustomized(Objects);
+
+    // Loop over each object being customized
+    for (const TWeakObjectPtr<UObject>& Object : Objects)
+    {
+        if (UAtumNeuralNetworkLayers* Layers = Cast<UAtumNeuralNetworkLayers>(Object.Get()))
+        {
+            // Get the property handles for LayerTypes and LayerObjects
+            TSharedPtr<IPropertyHandle> LayerTypesPropertyHandle = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UAtumNeuralNetworkLayers, LayerTypes), UAtumNeuralNetworkLayers::StaticClass());
+            TSharedPtr<IPropertyHandle> LayerObjectsPropertyHandle = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UAtumNeuralNetworkLayers, LayerObjects), UAtumNeuralNetworkLayers::StaticClass());
+
+            // Create a category for LayerTypes and display its default property widget
+            IDetailCategoryBuilder& LayerTypesCategory = DetailBuilder.EditCategory("Layer Types", FText::GetEmpty(), ECategoryPriority::Important);
+            LayerTypesCategory.AddProperty(LayerTypesPropertyHandle);
+
+            if (LayerObjectsPropertyHandle.IsValid())
+            {
+                uint32 NumChildren;
+                LayerObjectsPropertyHandle->GetNumChildren(NumChildren);
+
+                for (uint32 i = 0; i < NumChildren; i++)
+                {
+                    TSharedPtr<IPropertyHandle> ChildHandle = LayerObjectsPropertyHandle->GetChildHandle(i);
+                    if (ChildHandle.IsValid())
+                    {
+                        UObject* LayerObject = nullptr;
+                        ChildHandle->GetValue(LayerObject);
+
+                        if (ULlamaUnreal* LlamaUnreal = Cast<ULlamaUnreal>(LayerObject))
+                        {
+                            // Create a new category for each LlamaUnreal object
+                            FString CategoryName = FString::Printf(TEXT("Layer Object %d"), i);
+                            IDetailCategoryBuilder& LayerObjectCategory = DetailBuilder.EditCategory(*CategoryName, FText::GetEmpty(), ECategoryPriority::Important);
+
+                            // Add a custom row for the 'Load JSON' button at the top of the category
+                            LayerObjectCategory.AddCustomRow(FText::FromString("Llama Configuration"))
+                                .WholeRowContent()
+                                [
+                                    SNew(SHorizontalBox)
+                                    + SHorizontalBox::Slot()
+                                    .AutoWidth()
+                                    [
+                                        SNew(SButton)
+                                        .Text(FText::FromString("Load options from JSON"))
+                                        .OnClicked(FOnClicked::CreateLambda([this, LlamaUnreal]() -> FReply {
+                                            // Implement the logic to load the JSON file and set the values in the LlamaUnreal object
+                                            // You can use the existing SetFromFile function or create a new one specifically for this purpose
+                                            // LlamaUnreal->SetFromFile(FilePath);
+                                            if (LlamaUnreal)
+                                            {
+                                                LoadConfigurationFromFile(LlamaUnreal);
+                                            }
+                                            return FReply::Handled();
+                                        }))
+                                    ]
+                                ];
+
+                            // Add the default property widget for this LlamaUnreal object
+                            LayerObjectCategory.AddProperty(ChildHandle);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void FAtumNeuralNetworkLayersCustomization::OnJsonFilePathPicked(const FString& FilePath, ULlamaUnreal* LlamaUnreal)
+{
+    // Implement the logic to load the JSON file and set the values in the LlamaUnreal object
+    // You can use the existing SetFromFile function or create a new one specifically for this purpose
+    // LlamaUnreal->SetFromFile(FilePath);
+}
+
+void FAtumNeuralNetworkLayersCustomization::LoadConfigurationFromFile(ULlamaUnreal* LlamaUnreal)
+{
+    IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+    if (DesktopPlatform)
+    {
+        TArray<FString> OpenFilenames;
+        DesktopPlatform->OpenFileDialog(
+            nullptr, // Parent window handle
+            TEXT("Load JSON"), // Dialog title
+            TEXT(""), // Default path
+            TEXT(""), // Default file name
+            TEXT("JSON files (*.json)|*.json"), // File types
+            EFileDialogFlags::None,
+            OpenFilenames
+        );
+
+        if (OpenFilenames.Num() > 0)
+        {
+            const FString& FilePath = OpenFilenames[0];
+            FString JsonRaw;
+            if (FFileHelper::LoadFileToString(JsonRaw, *FilePath))
+            {
+                TSharedPtr<FJsonObject> JsonObject;
+                TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(JsonRaw);
+
+                if (FJsonSerializer::Deserialize(Reader, JsonObject) && JsonObject.IsValid())
+                {
+                    // Parse the JSON and apply settings to create a new FLlamaConfig instance
+                    LlamaConfig Config;
+
+                    // Set Config fields from JsonObject
+                    Config.vocab_size = JsonObject->GetIntegerField(TEXT("vocab_size"));
+                    Config.hidden_size = JsonObject->GetIntegerField(TEXT("hidden_size"));
+                    Config.intermediate_size = JsonObject->GetIntegerField(TEXT("intermediate_size"));
+                    Config.num_hidden_layers = JsonObject->GetIntegerField(TEXT("num_hidden_layers"));
+                    Config.num_attention_heads = JsonObject->GetIntegerField(TEXT("num_attention_heads"));
+                    Config.hidden_act = std::string(TCHAR_TO_UTF8(*JsonObject->GetStringField(TEXT("hidden_act"))));
+                    Config.max_position_embeddings = JsonObject->GetIntegerField(TEXT("max_position_embeddings"));
+                    Config.initializer_range = JsonObject->GetNumberField(TEXT("initializer_range"));
+                    Config.rms_norm_eps = JsonObject->GetNumberField(TEXT("rms_norm_eps"));
+                    Config.use_cache = JsonObject->GetBoolField(TEXT("use_cache"));
+                    Config.pad_token_id = JsonObject->GetIntegerField(TEXT("pad_token_id"));
+                    Config.bos_token_id = JsonObject->GetIntegerField(TEXT("bos_token_id"));
+                    Config.eos_token_id = JsonObject->GetIntegerField(TEXT("eos_token_id"));
+                    Config.tie_word_embeddings = JsonObject->GetBoolField(TEXT("tie_word_embeddings"));
+                    Config.output_hidden_states = JsonObject->GetBoolField(TEXT("output_hidden_states"));
+                    Config.output_attentions = JsonObject->GetBoolField(TEXT("output_attentions"));
+
+                    // Apply the new Config to the LlamaUnreal instance
+                    FAtumLlamaOptions NewOptions;
+                    NewOptions.SetFrom(Config);
+                    LlamaUnreal->SetOptions(NewOptions);
+
+                    // Refresh the UI to reflect the loaded values
+                    FPropertyEditorModule& PropertyEditorModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
+                    TSharedPtr<IDetailsView> DetailsView = PropertyEditorModule.FindDetailView(TEXT("AtumNeuralNetworkEditorDetailsTab"));
+                    if (DetailsView.IsValid())
+                    {
+                        DetailsView->SetObject(LlamaUnreal, true);
+                    }   
+                }
+            }
+        }
+    }
+}

--- a/Source/AtumEditor/Private/Assets/Network/AtumNeuralNetworkLayersCustomization.cpp
+++ b/Source/AtumEditor/Private/Assets/Network/AtumNeuralNetworkLayersCustomization.cpp
@@ -141,12 +141,17 @@ void FAtumNeuralNetworkLayersCustomization::LoadConfigurationFromFile(ULlamaUnre
                     Config.initializer_range = JsonObject->GetNumberField(TEXT("initializer_range"));
                     Config.rms_norm_eps = JsonObject->GetNumberField(TEXT("rms_norm_eps"));
                     Config.use_cache = JsonObject->GetBoolField(TEXT("use_cache"));
-                    Config.pad_token_id = JsonObject->GetIntegerField(TEXT("pad_token_id"));
-                    Config.bos_token_id = JsonObject->GetIntegerField(TEXT("bos_token_id"));
-                    Config.eos_token_id = JsonObject->GetIntegerField(TEXT("eos_token_id"));
-                    Config.tie_word_embeddings = JsonObject->GetBoolField(TEXT("tie_word_embeddings"));
-                    Config.output_hidden_states = JsonObject->GetBoolField(TEXT("output_hidden_states"));
-                    Config.output_attentions = JsonObject->GetBoolField(TEXT("output_attentions"));
+
+                    
+                    Config.pad_token_id = GetJsonIntField(JsonObject, TEXT("pad_token_id"), c10::nullopt);
+                    Config.bos_token_id = GetJsonIntField(JsonObject, TEXT("bos_token_id"), Config.bos_token_id).value();
+                    Config.eos_token_id = GetJsonIntField(JsonObject, TEXT("eos_token_id"), Config.eos_token_id).value();
+
+                    Config.tie_word_embeddings = GetJsonBoolField(JsonObject, TEXT("tie_word_embeddings"), Config.tie_word_embeddings);
+                    
+                    Config.output_hidden_states = GetJsonBoolField(JsonObject, TEXT("output_hidden_states"), Config.output_hidden_states);
+
+                    Config.output_attentions = GetJsonBoolField(JsonObject, TEXT("output_attentions"), Config.output_attentions);
 
                     // Apply the new Config to the LlamaUnreal instance
                     FAtumLlamaOptions NewOptions;
@@ -164,4 +169,25 @@ void FAtumNeuralNetworkLayersCustomization::LoadConfigurationFromFile(ULlamaUnre
             }
         }
     }
+}
+
+
+
+
+c10::optional<int32> FAtumNeuralNetworkLayersCustomization::GetJsonIntField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, c10::optional<int32> DefaultValue)
+{
+    if (JsonObject->HasField(FieldName))
+    {
+        return JsonObject->GetIntegerField(FieldName);
+    }
+    return DefaultValue;
+}
+
+bool FAtumNeuralNetworkLayersCustomization::GetJsonBoolField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, bool DefaultValue)
+{
+    if (JsonObject->HasField(FieldName))
+    {
+        return JsonObject->GetBoolField(FieldName);
+    }
+    return DefaultValue;
 }

--- a/Source/AtumEditor/Private/AtumEditorModule.cpp
+++ b/Source/AtumEditor/Private/AtumEditorModule.cpp
@@ -2,7 +2,9 @@
 
 #include "AtumEditorModule.h"
 
+#include "PropertyEditorModule.h"
 #include "Assets/Network/AssetTypeActions_AtumNeuralNetwork.h"
+#include "Assets/Network/AtumNeuralNetworkLayersCustomization.h"
 
 
 #define LOCTEXT_NAMESPACE "AtumEditorModule"
@@ -15,6 +17,9 @@ void FAtumEditorModule::StartupModule()
 		LOCTEXT("AtumAssetCategory", "Machine Learning")
 	);
 	AssetTools.RegisterAssetTypeActions(AtumNeuralNetworkAssetTypeActions);
+
+	FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
+	PropertyModule.RegisterCustomClassLayout("AtumNeuralNetworkLayers", FOnGetDetailCustomizationInstance::CreateStatic(&FAtumNeuralNetworkLayersCustomization::MakeInstance));
 }
 
 void FAtumEditorModule::ShutdownModule()
@@ -22,6 +27,12 @@ void FAtumEditorModule::ShutdownModule()
 	if (FAssetToolsModule::IsModuleLoaded())
 	{
 		FAssetToolsModule::GetModule().Get().UnregisterAssetTypeActions(AtumNeuralNetworkAssetTypeActions);
+	}
+
+	if (FModuleManager::Get().IsModuleLoaded("PropertyEditor"))
+	{
+		FPropertyEditorModule& PropertyModule = FModuleManager::GetModuleChecked<FPropertyEditorModule>("PropertyEditor");
+		PropertyModule.UnregisterCustomClassLayout("AtumNeuralNetworkLayers");
 	}
 }
 	

--- a/Source/AtumEditor/Public/Assets/Network/AtumNeuralNetworkLayersCustomization.h
+++ b/Source/AtumEditor/Public/Assets/Network/AtumNeuralNetworkLayersCustomization.h
@@ -1,0 +1,24 @@
+// © 2024 Chong-U Lim
+#pragma once
+
+#include "IDetailCustomization.h"
+#include "Input/Reply.h"
+
+class UAtumNeuralNetworkLayers;
+class ULlamaUnreal;
+
+#define LOCTEXT_NAMESPACE "LlamaUnrealCustomization"
+
+class FAtumNeuralNetworkLayersCustomization : public IDetailCustomization
+{
+public:
+	static TSharedRef<IDetailCustomization> MakeInstance();
+
+	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
+private:
+	void OnJsonFilePathPicked(const FString& FilePath, ULlamaUnreal* LlamaUnreal);
+	void LoadConfigurationFromFile(ULlamaUnreal* LlamaUnreal);
+};
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/AtumEditor/Public/Assets/Network/AtumNeuralNetworkLayersCustomization.h
+++ b/Source/AtumEditor/Public/Assets/Network/AtumNeuralNetworkLayersCustomization.h
@@ -2,7 +2,13 @@
 #pragma once
 
 #include "IDetailCustomization.h"
-#include "Input/Reply.h"
+#include "Dom/JsonObject.h"
+#include "CoreMinimal.h"
+#include "Macros/AtumMacrosGuards.h"
+
+TORCH_INCLUDES_START
+#include <c10/util/Optional.h>
+TORCH_INCLUDES_END
 
 class UAtumNeuralNetworkLayers;
 class ULlamaUnreal;
@@ -15,6 +21,9 @@ public:
 	static TSharedRef<IDetailCustomization> MakeInstance();
 
 	virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+
+	static c10::optional<int32> GetJsonIntField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, c10::optional<int32> DefaultValue);
+	static bool GetJsonBoolField(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName, bool DefaultValue);
 
 private:
 	void OnJsonFilePathPicked(const FString& FilePath, ULlamaUnreal* LlamaUnreal);


### PR DESCRIPTION
Building upon the foundational work in PR #4 , titled "[Editor] Add load from JSON button for LlamaOptions," this PR introduces the ability to handle default values when loading configurations for Llama models from JSON files. This addition accommodates scenarios where certain configuration parameters are omitted from the JSON file.

**Background and Rationale:**
The original PR #4 introduced the ability to load JSON Llama model configuration files found on the HuggingFace Hub from within the Unreal Editor. Building on this, I observed that handling scenarios where certain parameters were not specified would be necessary to ensure that models perform as expected. Thus, this enhancement focuses on managing missing parameters by utilizing the default values from the base Llama config, reducing potential errors and improving ease of use.